### PR TITLE
Reset grewform for multiple calls for the same form

### DIFF
--- a/jquery.grewform.js
+++ b/jquery.grewform.js
@@ -44,6 +44,10 @@
         });
     };
 
+    jQuery.fn.grewformReset = function() {
+        Rule.id = undefined;
+    };
+
     function debug(str) {
         //console.log('jQuery.brForms >>> '+str)
     }


### PR DESCRIPTION
Hi, 
I have added a function grewformReset that needs to be called in order to make grewform work on subsequential calls for the same html form. When I loaded a form with ajax, and then replaced the form with through an ajax call, grewform only worked the first time the form was loaded. If I call the grewformReset before calling grewform it works every time.

I also wrapped all the code in (function(){})(); in order to make sure that only the public jQuery.fn functions are available outside of grewform.

I must say that I really like the simplicity of usage you have achieved in grewform.
