### PR TITLE
better name for grewformReset, manual trigger of run_rules

### DIFF
--- a/jquery.grewform.js
+++ b/jquery.grewform.js
@@ -45,9 +45,13 @@
     };
 
     //reset all rules
-    jQuery.fn.grewformReset = function() {
+    jQuery.fn.grewform.reset = function() {
         Rule.id = undefined;
         Rule.all = [];
+    };
+
+    jQuery.fn.grewform.runRules = function() {
+        run_rules();
     };
 
     function debug(str) {


### PR DESCRIPTION
Changed jQuery.fn.grewformReset to jQuery.fn.grewform.reset which feels like a better name for the method.
Added jQuery.fn.grewform.runRules() to make it possible to force the execution of runRules, this is usable when you want to trigger a run_rules on something other than a change in a form.
