### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Quickstart
 	$().grewform.reset(); // reset all rules (i.e. turn off)
 	$().grewform.runRules(); //manualy run rules
 
-##Requirements
+## Requirements
  jQuery 1.7 or more
 
 Check out [demos](http://h1d.github.com/jquery-grewform/)

--- a/README_RU.md
+++ b/README_RU.md
@@ -41,7 +41,7 @@ Quickstart
 	$().grewform.reset(); //сбросить все правила ("выключить" плагин)
 	$().grewform.runRules(); //вручную запустить проверку правил
 
-##Требования
+## Требования
  jQuery 1.7 или выше
 
 Загляните в [примеры](http://h1d.github.com/jquery-grewform/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
